### PR TITLE
Fix: Upgrade gopsutil to V3 and remove the ioutil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/plgd-dev/go-coap/v2 v2.6.0
 	github.com/plgd-dev/kit/v2 v2.0.0-20211006190727-057b33161b90
 	github.com/robinson/gos7 v0.0.0-20211020181838-a2b780484319
-	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.22.7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/suapapa/go_eddystone v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,6 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
-github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil/v3 v3.22.7 h1:flKnuCMfUUrO+oAvwAd6GKZgnPzr098VA/UJ14nhJd4=
 github.com/shirou/gopsutil/v3 v3.22.7/go.mod h1:s648gW4IywYzUfE/KjXxUsqrqx/T2xO5VqOXxONeRfI=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/plugin/http_server/system_api.go
+++ b/plugin/http_server/system_api.go
@@ -10,8 +10,8 @@ import (
 	"github.com/i4de/rulex/typex"
 
 	"github.com/gin-gonic/gin"
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/disk"
 	"go.bug.st/serial"
 )
 
@@ -25,9 +25,7 @@ func Ping(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	c.Writer.Flush()
 }
 
-//
 // Get all plugins
-//
 func Plugins(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	data := []interface{}{}
 	plugins := e.AllPlugins()
@@ -41,9 +39,7 @@ func bToMb(b uint64) uint64 {
 	return b / 1024 / 1024
 }
 
-//
 // Get system infomation
-//
 func System(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	cpuPercent, _ := cpu.Percent(5*time.Millisecond, true)
 	parts, _ := disk.Partitions(true)
@@ -63,9 +59,7 @@ func System(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	}))
 }
 
-//
 // Get all Drivers
-//
 func Drivers(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	data := []interface{}{}
 	e.AllInEnd().Range(func(key, value interface{}) bool {
@@ -83,16 +77,12 @@ func Drivers(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	c.JSON(200, OkWithData(data))
 }
 
-//
 // Get statistics data
-//
 func Statistics(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	c.JSON(200, OkWithData(statistics.AllStatistics()))
 }
 
-//
 // Get statistics data
-//
 func SourceCount(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	allInEnd := e.AllInEnd()
 	allOutEnd := e.AllOutEnd()
@@ -172,9 +162,7 @@ func StartedAt(c *gin.Context, hh *HttpApiServer, e typex.RuleX) {
 	c.JSON(200, OkWithData(StartedTime))
 }
 
-//
 // 计算CPU平均使用率
-//
 func calculateCpuPercent(cpus []float64) float64 {
 	var acc float64 = 0
 	for _, v := range cpus {

--- a/target/tdengine_target.go
+++ b/target/tdengine_target.go
@@ -3,7 +3,7 @@ package target
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -58,9 +58,7 @@ func (td *tdEngineTarget) url() string {
 		td.mainConfig.Fqdn, td.mainConfig.Port, td.mainConfig.DbName)
 }
 
-//
 // 测试资源是否可用
-//
 func (td *tdEngineTarget) Test(inEndId string) bool {
 	return td.test()
 }
@@ -81,9 +79,7 @@ func (td *tdEngineTarget) Init(outEndId string, configMap map[string]interface{}
 	return errors.New("tdengine connect error")
 }
 
-//
 // 启动资源
-//
 func (td *tdEngineTarget) Start(cctx typex.CCTX) error {
 	td.Ctx = cctx.Ctx
 	td.CancelCTX = cctx.CancelCTX
@@ -103,65 +99,46 @@ func (td *tdEngineTarget) Start(cctx typex.CCTX) error {
 
 }
 
-//
 // 资源是否被启用
-//
 func (td *tdEngineTarget) Enabled() bool {
 	return true
 }
 
-//
 // 数据模型, 用来描述该资源支持的数据, 对应的是云平台的物模型
-//
 func (td *tdEngineTarget) DataModels() []typex.XDataModel {
 	return td.XDataModels
 }
 
-//
 // 重载: 比如可以在重启的时候把某些数据保存起来
-//
 func (td *tdEngineTarget) Reload() {
 
 }
 
-//
 // 挂起资源, 用来做暂停资源使用
-//
 func (td *tdEngineTarget) Pause() {
 }
 
-//
 // 获取资源状态
-//
 func (td *tdEngineTarget) Status() typex.SourceState {
 	return td.status
 }
 
-//
 // 获取资源绑定的的详情
-//
 func (td *tdEngineTarget) Details() *typex.OutEnd {
 	return td.RuleEngine.GetOutEnd(td.PointId)
 
 }
 
-//
 // 驱动接口, 通常用来和硬件交互
-//
 func (td *tdEngineTarget) Driver() typex.XExternalDriver {
 	return nil
 }
 
-//
-//
-//
 func (td *tdEngineTarget) Topology() []typex.TopologyPoint {
 	return []typex.TopologyPoint{}
 }
 
-//
 // 停止资源, 用来释放资源
-//
 func (td *tdEngineTarget) Stop() {
 	td.CancelCTX()
 	td.status = typex.SOURCE_STOP
@@ -182,13 +159,13 @@ func post(client http.Client,
 		return "", err2
 	}
 	if response.StatusCode != 200 {
-		bytes0, err3 := ioutil.ReadAll(response.Body)
+		bytes0, err3 := io.ReadAll(response.Body)
 		if err3 != nil {
 			return "", err3
 		}
 		return "", fmt.Errorf("Error:%v", string(bytes0))
 	}
-	bytes1, err3 := ioutil.ReadAll(response.Body)
+	bytes1, err3 := io.ReadAll(response.Body)
 	if err3 != nil {
 		return "", err3
 	}

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -60,7 +60,7 @@ func publicKeyAuthFunc(kPath string) ssh.AuthMethod {
 	if err != nil {
 		glogger.GLogger.Fatal("find key's home dir failed", err)
 	}
-	key, err := ioutil.ReadFile(keyPath)
+	key, err := os.ReadFile(keyPath)
 	if err != nil {
 		glogger.GLogger.Fatal("ssh key file read failed", err)
 	}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -15,7 +15,6 @@ import (
 	"github.com/i4de/rulex/typex"
 )
 
-//
 func HttpPost(data map[string]interface{}, url string) string {
 	p, errs1 := json.Marshal(data)
 	if errs1 != nil {
@@ -27,7 +26,7 @@ func HttpPost(data map[string]interface{}, url string) string {
 	}
 	defer r.Body.Close()
 
-	body, errs5 := ioutil.ReadAll(r.Body)
+	body, errs5 := io.ReadAll(r.Body)
 	if errs5 != nil {
 		glogger.GLogger.Fatal(errs5)
 	}
@@ -48,7 +47,7 @@ func HttpGet(api string) string {
 		return ""
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		glogger.GLogger.Error(err)
 		return ""

--- a/utils/http_util.go
+++ b/utils/http_util.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -33,7 +33,7 @@ func Post(client http.Client, data interface{},
 		return "", err2
 	}
 	if response.StatusCode != 200 {
-		bytes0, err3 := ioutil.ReadAll(response.Body)
+		bytes0, err3 := io.ReadAll(response.Body)
 		if err3 != nil {
 			return "", err3
 		}
@@ -41,7 +41,7 @@ func Post(client http.Client, data interface{},
 	}
 	var r []byte
 	response.Body.Read(r)
-	bytes1, err3 := ioutil.ReadAll(response.Body)
+	bytes1, err3 := io.ReadAll(response.Body)
 	if err3 != nil {
 		return "", err3
 	}
@@ -67,7 +67,7 @@ func Get(client http.Client, url string) string {
 		return ""
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		glogger.GLogger.Error(err)
 		return ""


### PR DESCRIPTION
# Description

- 升级 gopsutil v3 ，用于解决 MacOS 12.0 废弃 'IOMasterPort'  的 warning
- 更换 ioutil -> io | os ，[Go1.16 废弃此包](https://pkg.go.dev/io/ioutil)

# Checklist

- [x] 编译正常